### PR TITLE
Handling "\r\n" in splitFirstLine()

### DIFF
--- a/compat-nollup.js
+++ b/compat-nollup.js
@@ -43,15 +43,19 @@ function CompatNollup({
   }
 
   const splitFirstLine = code => {
-    const eolIndex = code.indexOf('\n')
-    if (eolIndex === -1) {
+    const regex = /(.*?)\r?\n(.*)/s
+    const matches = code.match(regex)
+    if (matches) {
+      const firstLine = matches[1]
+      const restLines = matches[2]
+      if (/\bimport\.meta\b/.test(firstLine)) {
+        return [firstLine, restLines, '']
+      }
+      return [firstLine, '', restLines]
+    }
+    else {
       return ['', '', code]
     }
-    const firstLine = code.slice(0, eolIndex)
-    if (/\bimport\.meta\b/.test(firstLine)) {
-      return [firstLine, code.slice(eolIndex + 1), '']
-    }
-    return [firstLine, '', code.slice(eolIndex + 1)]
   }
 
   const hasComment = line =>


### PR DESCRIPTION
Wrong code:
```js
const splitFirstLine = code => {
  const eolIndex = code.indexOf('\n')
  if (eolIndex === -1) {
    return ['', '', code]
  }
  const firstLine = code.slice(0, eolIndex)
  if (/\bimport\.meta\b/.test(firstLine)) {
    return [firstLine, code.slice(eolIndex + 1), '']
  }
  return [firstLine, '', code.slice(eolIndex + 1)]
}
```
1. Right code (long regex version):
```js
const splitFirstLine = code => {
  const regex = /(.*?)(?:\r\n|[\n\v\f\r\x85\u2028\u2029])(.*)/s
  const matches = code.match(regex)
  if (matches) {
    const firstLine = matches[1]
    const restLines = matches[2]
    if (/\bimport\.meta\b/.test(firstLine)) {
      return [firstLine, restLines, '']
    }
    return [firstLine, '', restLines]
  }
  else {
    return ['', '', code]
  }
}
```
2. Right code (short regex version):
```js
  const splitFirstLine = code => {
    const regex = /(.*?)(?:\r\n|[\n\r])(.*)/s
    const matches = code.match(regex)
    if (matches) {
      const firstLine = matches[1]
      const restLines = matches[2]
      if (/\bimport\.meta\b/.test(firstLine)) {
        return [firstLine, restLines, '']
      }
      return [firstLine, '', restLines]
    }
    else {
      return ['', '', code]
    }
  }
```
3. Right code (shortest regex version):
```js
const splitFirstLine = code => {
  const regex = /(.*?)\r?\n(.*)/s
  const matches = code.match(regex)
  if (matches) {
    const firstLine = matches[1]
    const restLines = matches[2]
    if (/\bimport\.meta\b/.test(firstLine)) {
      return [firstLine, restLines, '']
    }
    return [firstLine, '', restLines]
  }
  else {
    return ['', '', code]
  }
}
```
4. Right code (not using regex version):
```js
const splitFirstLine = code => {
  let eolIndex = code.indexOf('\n')
  if (eolIndex === -1) {
    return ['', '', code]
  }
  else {
    let eolSize = 1
    let eolIndex2 = code.indexOf('\r\n')
    if (eolIndex2 !== -1 && eolIndex2 < eolIndex) {
      eolIndex = eolIndex2
      eolSize = 2
    }
    const firstLine = code.slice(0, eolIndex)
    const restLines = code.slice(eolIndex + eolSize)
    if (/\bimport\.meta\b/.test(firstLine)) {
      return [firstLine, restLines, '']
    }
    return [firstLine, '', restLines]
  }
}
```
I chose the 3th version.